### PR TITLE
Remove uniqueness requirement on attachments

### DIFF
--- a/invoice-spec.json
+++ b/invoice-spec.json
@@ -123,7 +123,11 @@
       }
     },
     "attachments": {
-      "$ref": "#/definitions/name-value-array"
+      "uniqueItems": false,
+      "maxItems": 100,
+      "items": {
+        "$ref": "#/definitions/name-value"
+      }
     },
     "text": {
       "type": "string",


### PR DESCRIPTION
@michaelbornhede for consideration. My preference would be that we filter out the duplicates on the source.

Note2self. Prior to merge update version to today's date.