### PR TITLE
Disallow undefined top-level fields

### DIFF
--- a/invoice-spec.json
+++ b/invoice-spec.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "invoice/v2/2023-02-01",
+  "$id": "invoice/v2/2024-03-22",
   "title": "Invoice",
   "type": "object",
   "definitions": {
@@ -84,6 +84,7 @@
     "site",
     "stage"
   ],
+  "additionalProperties": false,
   "properties": {
     "id": {
       "$ref": "#/definitions/restricted-string",

--- a/invoice-spec.json
+++ b/invoice-spec.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "invoice/v2/2024-03-22",
+  "$id": "invoice/v2/2025-02-02",
   "title": "Invoice",
   "type": "object",
   "definitions": {


### PR DESCRIPTION
Remember to import this into serverless if we accept and merge.

I think it makes sense that we disallow anything high-level in the invoice spec to avoid typos in the integration.  One could argue that this makes it harder to extend the format.  A program is *required* to ignore any top level fields that it is not aware of.  Fine. But that still does not help us then with the first issue.. Someone wanted to send "flow" but we got "flows"